### PR TITLE
Make user id configurable

### DIFF
--- a/connector/oidc/oidc_test.go
+++ b/connector/oidc/oidc_test.go
@@ -115,6 +115,38 @@ func TestHandleCallBack(t *testing.T) {
 	expectEqual(t, identity.UserID, "test-subject")
 }
 
+func TestHandleCallBackWithUserNameKey(t *testing.T) {
+	testServer := testSetup(t)
+	defer testServer.Close()
+
+	serverURL := testServer.URL
+	testConfig := Config{
+		Issuer:       serverURL,
+		ClientID:     "testClient",
+		ClientSecret: "testSecret",
+		Scopes:       []string{"groups"},
+		RedirectURI:  serverURL + "/callback",
+		GroupsKey:    "groups_key",
+		UserNameKey:  "user_name_key",
+	}
+	conn := newConnector(t, testConfig)
+
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	if err != nil {
+		t.Fatal("handle callback failed", err)
+	}
+
+	expectEqual(t, len(identity.Groups), 1)
+	expectEqual(t, identity.Groups[0], "test-group")
+	expectEqual(t, identity.Name, "test-name")
+	expectEqual(t, identity.Username, "test-username")
+	expectEqual(t, identity.Email, "test-email")
+	expectEqual(t, identity.EmailVerified, true)
+	expectEqual(t, identity.UserID, "test-subject")
+}
+
 func TestHandleCallBackWithUserIDKey(t *testing.T) {
 	testServer := testSetup(t)
 	defer testServer.Close()


### PR DESCRIPTION
related: https://github.com/concourse/concourse/issues/3855

I have tested in my local concourse (with Auth0).
Auth0 returns claims as follows.
```json
{"aud":"4v6S5xxxxxxxxxxxxxxxx", "email":"cappyzawa@yahoo.ne.jp", "email_verified":false, "exp":1.557999894e+09, "iat":"nyaaaaaaaaaa", "iss":"https://mydomain.auth0.com/", "name":"cappyzawa@yahoo.ne.jp", "nickname":"cappyzawa", "picture":"https://s.gravatar.com/avatar/6a6d6d3537875bb94e3fa9e685112e1a?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fca.png", "sub":"auth0|5cXXXXXXXXXXXfooXXbar", "updated_at":"2019-05-15T13:30:54.490Z"}
```

Before, `sub` claim(`auth0|5cXXXXXXXXXXXfooXXbar`) must be set as oidc user.
These changes enable to specify claims as oidc user.

in my test:
Login successful when `CONCOURSE_OIDC_USER_ID_KEY: nickname` and `CONCOURSE_MAIN_TEAM_OIDC_USER: cappyzawa` is set.