### PR TITLE
#4535 - Allow users of spaceAuditor/ spaceManager roles to login via cf-auth to concourse

### DIFF
--- a/connector/cf/cf.go
+++ b/connector/cf/cf.go
@@ -63,6 +63,17 @@ type Entity struct {
 	OrganizationGuid string `json:"organization_guid"`
 }
 
+type Space struct {
+	Name    string
+	Guid    string
+	OrgGuid string
+}
+
+type Org struct {
+	Name string
+	Guid string
+}
+
 func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error) {
 	var err error
 
@@ -180,6 +191,108 @@ func (c *cfConnector) LoginURL(scopes connector.Scopes, callbackURL, state strin
 	return oauth2Config.AuthCodeURL(state), nil
 }
 
+func fetchRoleSpaces(baseUrl, path string, client *http.Client) ([]Space, error) {
+	var spaces []Space
+
+	resources, err := fetchResources(baseUrl, path, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch resources: %v", err)
+	}
+
+	for _, resource := range resources {
+		spaces = append(spaces, Space{
+			Name:    resource.Entity.Name,
+			Guid:    resource.Metadata.Guid,
+			OrgGuid: resource.Entity.OrganizationGuid,
+		})
+	}
+
+	return spaces, nil
+}
+
+func fetchOrgs(baseUrl, path string, client *http.Client) ([]Org, error) {
+	var orgs []Org
+
+	resources, err := fetchResources(baseUrl, path, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch resources: %v", err)
+	}
+
+	for _, resource := range resources {
+		orgs = append(orgs, Org{
+			Name: resource.Entity.Name,
+			Guid: resource.Metadata.Guid,
+		})
+	}
+
+	return orgs, nil
+}
+
+func fetchResources(baseUrl, path string, client *http.Client) ([]Resource, error) {
+	var (
+		resources []Resource
+		url       string
+	)
+
+	for {
+		url = fmt.Sprintf("%s%s", baseUrl, path)
+
+		resp, err := client.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute request: %v", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("unsuccessful status code %d", resp.StatusCode)
+		}
+
+		response := CCResponse{}
+		err = json.NewDecoder(resp.Body).Decode(&response)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse spaces: %v", err)
+		}
+
+		resources = append(resources, response.Resources...)
+
+		path = response.NextUrl
+		if path == "" {
+			break
+		}
+	}
+
+	return resources, nil
+}
+
+func getGroupsClaims(orgs []Org, spaces []Space) (groupsClaims []string) {
+
+	var (
+		orgMap    = map[string]string{}
+		orgSpaces = map[string][]string{}
+	)
+
+	for _, org := range orgs {
+		orgMap[org.Guid] = org.Name
+		orgSpaces[org.Name] = []string{}
+	}
+
+	for _, space := range spaces {
+		orgName := orgMap[space.OrgGuid]
+		orgSpaces[orgName] = append(orgSpaces[orgName], space.Name)
+		groupsClaims = append(groupsClaims, space.Guid)
+	}
+
+	for orgName, spaceNames := range orgSpaces {
+		if len(spaceNames) > 0 {
+			for _, spaceName := range spaceNames {
+				groupsClaims = append(groupsClaims, fmt.Sprintf("%s:%s", orgName, spaceName))
+			}
+		} else {
+			groupsClaims = append(groupsClaims, fmt.Sprintf("%s", orgName))
+		}
+	}
+	return groupsClaims
+}
+
 func (c *cfConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
 
 	q := r.URL.Query()
@@ -228,81 +341,37 @@ func (c *cfConnector) HandleCallback(s connector.Scopes, r *http.Request) (ident
 	identity.Email, _ = userInfoResult["email"].(string)
 	identity.EmailVerified, _ = userInfoResult["email_verified"].(bool)
 
-	var orgMap = make(map[string]string)
-	var orgSpaces = make(map[string][]string)
-	var groupsClaims []string
+	var (
+		devPath     = fmt.Sprintf("/v2/users/%s/spaces", identity.UserID)
+		auditorPath = fmt.Sprintf("/v2/users/%s/audited_spaces", identity.UserID)
+		managerPath = fmt.Sprintf("/v2/users/%s/managed_spaces", identity.UserID)
+		orgsPath    = fmt.Sprintf("/v2/users/%s/organizations", identity.UserID)
+	)
 
 	if s.Groups {
-		// fetch orgs
-
-		var orgs CCResponse
-		var nextUrl = fmt.Sprintf("%s/v2/users/%s/organizations", c.apiURL, identity.UserID)
-		for moreResults := true; moreResults; moreResults = orgs.NextUrl != "" {
-			orgsResp, err := client.Get(nextUrl)
-			if err != nil {
-				return identity, fmt.Errorf("CF Connector: failed to execute request for orgs: %v", err)
-			}
-			if orgsResp.StatusCode != http.StatusOK {
-				return identity, fmt.Errorf("CF Connector: failed to execute request for orgs: status %d", orgsResp.StatusCode)
-			}
-
-			orgs = CCResponse{}
-			err = json.NewDecoder(orgsResp.Body).Decode(&orgs)
-			if err != nil {
-				return identity, fmt.Errorf("CF Connector: failed to parse orgs: %v", err)
-			}
-
-			for _, resource := range orgs.Resources {
-				orgMap[resource.Metadata.Guid] = resource.Entity.Name
-				orgSpaces[resource.Entity.Name] = []string{}
-			}
-
-			if orgs.NextUrl != "" {
-				nextUrl = fmt.Sprintf("%s%s", c.apiURL, orgs.NextUrl)
-			}
+		orgs, err := fetchOrgs(c.apiURL, orgsPath, client)
+		if err != nil {
+			return identity, fmt.Errorf("failed to fetch organizaitons: %v", err)
 		}
 
-		// fetch spaces
-		var spaces CCResponse
-		nextUrl = fmt.Sprintf("%s/v2/users/%s/spaces", c.apiURL, identity.UserID)
-		for moreResults := true; moreResults; moreResults = spaces.NextUrl != "" {
-			spacesResp, err := client.Get(nextUrl)
-			if err != nil {
-				return identity, fmt.Errorf("CF Connector: failed to execute request for spaces: %v", err)
-			}
-			if spacesResp.StatusCode != http.StatusOK {
-				return identity, fmt.Errorf("CF Connector: failed to execute request for spaces: status %d", spacesResp.StatusCode)
-			}
-
-			spaces = CCResponse{}
-			err = json.NewDecoder(spacesResp.Body).Decode(&spaces)
-			if err != nil {
-				return identity, fmt.Errorf("CF Connector: failed to parse spaces: %v", err)
-			}
-
-			for _, resource := range spaces.Resources {
-				orgName := orgMap[resource.Entity.OrganizationGuid]
-				orgSpaces[orgName] = append(orgSpaces[orgName], resource.Entity.Name)
-
-				groupsClaims = append(groupsClaims, resource.Metadata.Guid)
-			}
-
-			if spaces.NextUrl != "" {
-				nextUrl = fmt.Sprintf("%s%s", c.apiURL, spaces.NextUrl)
-			}
+		developerSpaces, err := fetchRoleSpaces(c.apiURL, devPath, client)
+		if err != nil {
+			return identity, fmt.Errorf("failed to fetch spaces for developer roles: %v", err)
 		}
 
-		for orgName, spaceNames := range orgSpaces {
-			if len(spaceNames) > 0 {
-				for _, spaceName := range spaceNames {
-					groupsClaims = append(groupsClaims, fmt.Sprintf("%s:%s", orgName, spaceName))
-				}
-			} else {
-				groupsClaims = append(groupsClaims, fmt.Sprintf("%s", orgName))
-			}
+		auditorSpaces, err := fetchRoleSpaces(c.apiURL, auditorPath, client)
+		if err != nil {
+			return identity, fmt.Errorf("failed to fetch spaces for developer roles: %v", err)
 		}
 
-		identity.Groups = groupsClaims
+		managerSpaces, err := fetchRoleSpaces(c.apiURL, managerPath, client)
+		if err != nil {
+			return identity, fmt.Errorf("failed to fetch spaces for developer roles: %v", err)
+		}
+
+		spaces := append(developerSpaces, append(auditorSpaces, managerSpaces...)...)
+
+		identity.Groups = getGroupsClaims(orgs, spaces)
 	}
 
 	if s.OfflineAccess {

--- a/connector/cf/cf_test.go
+++ b/connector/cf/cf_test.go
@@ -50,13 +50,21 @@ func TestHandleCallback(t *testing.T) {
 		expectEqual(t, err, nil)
 
 		sort.Strings(identity.Groups)
-		expectEqual(t, len(identity.Groups), 6)
+		expectEqual(t, len(identity.Groups), 14)
 		expectEqual(t, identity.Groups[0], "some-org-name-1:some-space-name-1")
-		expectEqual(t, identity.Groups[1], "some-org-name-2:some-space-name-2")
-		expectEqual(t, identity.Groups[2], "some-org-name-3")
-		expectEqual(t, identity.Groups[3], "some-org-name-4")
-		expectEqual(t, identity.Groups[4], "some-space-guid-1")
-		expectEqual(t, identity.Groups[5], "some-space-guid-2")
+		expectEqual(t, identity.Groups[1], "some-org-name-1:some-space-name-1")
+		expectEqual(t, identity.Groups[2], "some-org-name-1:some-space-name-1")
+		expectEqual(t, identity.Groups[3], "some-org-name-2:some-space-name-2")
+		expectEqual(t, identity.Groups[4], "some-org-name-2:some-space-name-2")
+		expectEqual(t, identity.Groups[5], "some-org-name-2:some-space-name-2")
+		expectEqual(t, identity.Groups[6], "some-org-name-3")
+		expectEqual(t, identity.Groups[7], "some-org-name-4")
+		expectEqual(t, identity.Groups[8], "some-space-guid-1")
+		expectEqual(t, identity.Groups[9], "some-space-guid-1")
+		expectEqual(t, identity.Groups[10], "some-space-guid-1")
+		expectEqual(t, identity.Groups[11], "some-space-guid-2")
+		expectEqual(t, identity.Groups[12], "some-space-guid-2")
+		expectEqual(t, identity.Groups[13], "some-space-guid-2")
 	})
 
 	t.Run("CallbackWithoutGroupsScope", func(t *testing.T) {
@@ -79,6 +87,64 @@ func TestHandleCallback(t *testing.T) {
 		expectEqual(t, err, nil)
 		expectNotEqual(t, cData.AccessToken, "")
 	})
+}
+
+func testSpaceHandler(reqUrl, spaceApiEndpoint string) (result map[string]interface{}) {
+	fullUrl := fmt.Sprintf("%s?order-direction=asc&page=2&results-per-page=50", spaceApiEndpoint)
+	if strings.Contains(reqUrl, fullUrl) {
+		result = map[string]interface{}{
+			"resources": []map[string]interface{}{
+				{
+					"metadata": map[string]string{"guid": "some-space-guid-2"},
+					"entity":   map[string]string{"name": "some-space-name-2", "organization_guid": "some-org-guid-2"},
+				},
+			},
+		}
+	} else {
+		nextUrl := fmt.Sprintf("/v2/users/12345/%s?order-direction=asc&page=2&results-per-page=50", spaceApiEndpoint)
+		result = map[string]interface{}{
+			"next_url": nextUrl,
+			"resources": []map[string]interface{}{
+				{
+					"metadata": map[string]string{"guid": "some-space-guid-1"},
+					"entity":   map[string]string{"name": "some-space-name-1", "organization_guid": "some-org-guid-1"},
+				},
+			},
+		}
+	}
+	return result
+}
+
+func testOrgHandler(reqUrl string) (result map[string]interface{}) {
+	if strings.Contains(reqUrl, "organizations?order-direction=asc&page=2&results-per-page=50") {
+		result = map[string]interface{}{
+			"resources": []map[string]interface{}{
+				{
+					"metadata": map[string]string{"guid": "some-org-guid-3"},
+					"entity":   map[string]string{"name": "some-org-name-3"},
+				},
+				{
+					"metadata": map[string]string{"guid": "some-org-guid-4"},
+					"entity":   map[string]string{"name": "some-org-name-4"},
+				},
+			},
+		}
+	} else {
+		result = map[string]interface{}{
+			"next_url": "/v2/users/12345/organizations?order-direction=asc&page=2&results-per-page=50",
+			"resources": []map[string]interface{}{
+				{
+					"metadata": map[string]string{"guid": "some-org-guid-1"},
+					"entity":   map[string]string{"name": "some-org-name-1"},
+				},
+				{
+					"metadata": map[string]string{"guid": "some-org-guid-2"},
+					"entity":   map[string]string{"name": "some-org-name-2"},
+				},
+			},
+		}
+	}
+	return result
 }
 
 func testSetup() *httptest.Server {
@@ -123,58 +189,21 @@ func testSetup() *httptest.Server {
 	mux.HandleFunc("/v2/users/", func(w http.ResponseWriter, r *http.Request) {
 		var result map[string]interface{}
 
-		if strings.Contains(r.URL.String(), "spaces") {
-			if strings.Contains(r.URL.String(), "spaces?order-direction=asc&page=2&results-per-page=50") {
-				result = map[string]interface{}{
-					"resources": []map[string]interface{}{
-						{
-							"metadata": map[string]string{"guid": "some-space-guid-2"},
-							"entity":   map[string]string{"name": "some-space-name-2", "organization_guid": "some-org-guid-2"},
-						},
-					},
-				}
-			} else {
-				result = map[string]interface{}{
-					"next_url": "/v2/users/12345/spaces?order-direction=asc&page=2&results-per-page=50",
-					"resources": []map[string]interface{}{
-						{
-							"metadata": map[string]string{"guid": "some-space-guid-1"},
-							"entity":   map[string]string{"name": "some-space-name-1", "organization_guid": "some-org-guid-1"},
-						},
-					},
-				}
-			}
+		reqUrl := r.URL.String()
+		if strings.Contains(reqUrl, "/spaces") {
+			result = testSpaceHandler(reqUrl, "spaces")
 		}
 
-		if strings.Contains(r.URL.String(), "organizations") {
-			if strings.Contains(r.URL.String(), "organizations?order-direction=asc&page=2&results-per-page=50") {
-				result = map[string]interface{}{
-					"resources": []map[string]interface{}{
-						{
-							"metadata": map[string]string{"guid": "some-org-guid-3"},
-							"entity":   map[string]string{"name": "some-org-name-3"},
-						},
-						{
-							"metadata": map[string]string{"guid": "some-org-guid-4"},
-							"entity":   map[string]string{"name": "some-org-name-4"},
-						},
-					},
-				}
-			} else {
-				result = map[string]interface{}{
-					"next_url": "/v2/users/12345/organizations?order-direction=asc&page=2&results-per-page=50",
-					"resources": []map[string]interface{}{
-						{
-							"metadata": map[string]string{"guid": "some-org-guid-1"},
-							"entity":   map[string]string{"name": "some-org-name-1"},
-						},
-						{
-							"metadata": map[string]string{"guid": "some-org-guid-2"},
-							"entity":   map[string]string{"name": "some-org-name-2"},
-						},
-					},
-				}
-			}
+		if strings.Contains(reqUrl, "/audited_spaces") {
+			result = testSpaceHandler(reqUrl, "audited_spaces")
+		}
+
+		if strings.Contains(reqUrl, "/managed_spaces") {
+			result = testSpaceHandler(reqUrl, "managed_spaces")
+		}
+
+		if strings.Contains(reqUrl, "organizations") {
+			result = testOrgHandler(reqUrl)
 		}
 
 		json.NewEncoder(w).Encode(result)


### PR DESCRIPTION
fixes: https://github.com/concourse/concourse/issues/4535

Back Story:
If a user switches their role to Auditor within their cf-auth org, they lose access to their Concourse teams.

Current Changes:
- modified unit test to test if users are of spaceAuditor/ spaceManager role can cf-auth login to concourse with dex 
- added functionalities to login using `/v2/users/id/audited_spaces` for auditor users


