### PR TITLE
Use the Username field instead of Name

### DIFF
--- a/connector/gitlab/gitlab.go
+++ b/connector/gitlab/gitlab.go
@@ -132,14 +132,10 @@ func (c *gitlabConnector) HandleCallback(s connector.Scopes, r *http.Request) (i
 		return identity, fmt.Errorf("gitlab: get user: %v", err)
 	}
 
-	username := user.Name
-	if username == "" {
-		username = user.Email
-	}
 	identity = connector.Identity{
 		UserID:        strconv.Itoa(user.ID),
-		Name:          username,
-		Username:      username,
+		Name:          user.Name,
+		Username:      user.Username,
 		Email:         user.Email,
 		EmailVerified: true,
 	}


### PR DESCRIPTION
Name is a non-unique, user-defined field that can be changed to
anything in Gitlab, therefore not representing a users username in
Gitlab.

closes #7 

CC: @taylorsilva 