### PR TITLE
Add support for a list of groups represented as maps in OAuth.

### DIFF
--- a/connector/oauth/oauth.go
+++ b/connector/oauth/oauth.go
@@ -249,6 +249,9 @@ func (c *oauthConnector) addGroupsFromMap(groups map[string]bool, result map[str
 		if groupString, ok := group.(string); ok {
 			groups[groupString] = true
 		}
+		if groupMap, ok := group.(map[string]interface{}); ok {
+			groups[groupMap["name"]] = true
+		}
 	}
 
 	return nil

--- a/connector/oauth/oauth.go
+++ b/connector/oauth/oauth.go
@@ -250,7 +250,9 @@ func (c *oauthConnector) addGroupsFromMap(groups map[string]bool, result map[str
 			groups[groupString] = true
 		}
 		if groupMap, ok := group.(map[string]interface{}); ok {
-			groups[groupMap["name"]] = true
+			if groupName, ok := groupMap["name"].(string); ok {
+				groups[groupName] = true
+			}
 		}
 	}
 

--- a/connector/oauth/oauth_test.go
+++ b/connector/oauth/oauth_test.go
@@ -100,6 +100,42 @@ func TestHandleCallBackForGroupsInUserInfo(t *testing.T) {
 	assert.Equal(t, identity.EmailVerified, false)
 }
 
+func TestHandleCallBackForGroupMapsInUserInfo(t *testing.T) {
+	tokenClaims := map[string]interface{}{}
+
+	userInfoClaims := map[string]interface{}{
+		"name":               "test-name",
+		"user_id_key":        "test-user-id",
+		"user_name_key":      "test-username",
+		"preferred_username": "test-preferred-username",
+		"mail":               "mod_mail",
+		"has_verified_email": false,
+		"groups_key": []interface{}{
+			map[string]string{"name": "admin-group", "id": "111"},
+			map[string]string{"name": "user-group", "id": "222"},
+		},
+	}
+
+	testServer := testSetup(t, tokenClaims, userInfoClaims)
+	defer testServer.Close()
+
+	conn := newConnector(t, testServer.URL)
+	req := newRequestWithAuthCode(t, testServer.URL, "some-code")
+
+	identity, err := conn.HandleCallback(connector.Scopes{Groups: true}, req)
+	assert.Equal(t, err, nil)
+
+	sort.Strings(identity.Groups)
+	assert.Equal(t, len(identity.Groups), 2)
+	assert.Equal(t, identity.Groups[0], "admin-group")
+	assert.Equal(t, identity.Groups[1], "user-group")
+	assert.Equal(t, identity.UserID, "test-user-id")
+	assert.Equal(t, identity.Username, "test-username")
+	assert.Equal(t, identity.PreferredUsername, "test-preferred-username")
+	assert.Equal(t, identity.Email, "mod_mail")
+	assert.Equal(t, identity.EmailVerified, false)
+}
+
 func TestHandleCallBackForGroupsInToken(t *testing.T) {
 	tokenClaims := map[string]interface{}{
 		"groups_key": []string{"test-group"},


### PR DESCRIPTION
Hi, 

#### Overview

I read about DCO, etc. I am not familiar with Golang yet, so I have created a draft PR to discuss 
the problem which the fix outlines and possibly? solves before investing more time.

#### What this PR does / why we need it

OAuth supports providing user groups in userinfo token. Yet there are cases when groups are represented 
as a list of maps, not strings e.g. "groups":[{"id":"1", "name":"gr1"},{"id": "2", "name":"gr2"}]. Current code
does not support that and ignores groups information.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
