### PR TITLE
Update CF connector to implement new Connector interface

### DIFF
--- a/connector/cloudfoundry/cloudfoundry.go
+++ b/connector/cloudfoundry/cloudfoundry.go
@@ -137,7 +137,10 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
 
 	var apiResult infoResp
 
-	json.NewDecoder(apiResp.Body).Decode(&apiResult)
+	err = json.NewDecoder(apiResp.Body).Decode(&apiResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed-to-decode-response-from-api: %w", err)
+	}
 
 	uaaURL := strings.TrimRight(apiResult.Links.Login.Href, "/")
 	uaaResp, err := cloudfoundryConn.httpClient.Get(fmt.Sprintf("%s/.well-known/openid-configuration", uaaURL))
@@ -145,8 +148,8 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
 		return nil, fmt.Errorf("failed-to-send-request-to-uaa-api: %w", err)
 	}
 
-	if apiResp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("request failed with status %d", apiResp.StatusCode)
+	if uaaResp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("request failed with status %d", uaaResp.StatusCode)
 		return nil, fmt.Errorf("failed-to-get-well-known-config-response-from-api: %w", err)
 	}
 

--- a/connector/cloudfoundry/cloudfoundry.go
+++ b/connector/cloudfoundry/cloudfoundry.go
@@ -200,9 +200,9 @@ func newHTTPClient(rootCAs []string, insecureSkipVerify bool) (*http.Client, err
 	}, nil
 }
 
-func (c *cloudfoundryConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, error) {
+func (c *cloudfoundryConnector) LoginURL(scopes connector.Scopes, callbackURL, state string) (string, []byte, error) {
 	if c.redirectURI != callbackURL {
-		return "", fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
+		return "", nil, fmt.Errorf("expected callback URL %q did not match the URL in the config %q", callbackURL, c.redirectURI)
 	}
 
 	oauth2Config := &oauth2.Config{
@@ -213,7 +213,7 @@ func (c *cloudfoundryConnector) LoginURL(scopes connector.Scopes, callbackURL, s
 		Scopes:       []string{"openid", "cloud_controller.read"},
 	}
 
-	return oauth2Config.AuthCodeURL(state), nil
+	return oauth2Config.AuthCodeURL(state), nil, nil
 }
 
 func filterUserOrgsSpaces(userOrgsSpaces []resource, orgs []resource, spaces []resource) ([]org, []space) {
@@ -325,7 +325,7 @@ func getGroupsClaims(orgs []org, spaces []space) []string {
 	return groups
 }
 
-func (c *cloudfoundryConnector) HandleCallback(s connector.Scopes, r *http.Request) (identity connector.Identity, err error) {
+func (c *cloudfoundryConnector) HandleCallback(s connector.Scopes, connData []byte, r *http.Request) (identity connector.Identity, err error) {
 	q := r.URL.Query()
 	if errType := q.Get("error"); errType != "" {
 		return identity, errors.New(q.Get("error_description"))

--- a/connector/cloudfoundry/cloudfoundry_test.go
+++ b/connector/cloudfoundry/cloudfoundry_test.go
@@ -26,6 +26,51 @@ func TestOpen(t *testing.T) {
 	expectEqual(t, conn.redirectURI, testServer.URL+"/callback")
 }
 
+func TestOpenWellKnownNon200(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			url := fmt.Sprintf("http://%s", r.Host)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"links": map[string]interface{}{
+					"login": map[string]string{
+						"href": url,
+					},
+				},
+			})
+		case "/.well-known/openid-configuration":
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{
+				"token_endpoint":         "http://example.invalid/token",
+				"authorization_endpoint": "http://example.invalid/authorize",
+				"userinfo_endpoint":      "http://example.invalid/userinfo",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer testServer.Close()
+
+	testConfig := Config{
+		APIURL:             testServer.URL,
+		ClientID:           "test-client",
+		ClientSecret:       "secret",
+		RedirectURI:        testServer.URL + "/callback",
+		InsecureSkipVerify: true,
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+
+	_, err := testConfig.Open("id", log)
+	if err == nil {
+		t.Fatal("expected error when UAA well-known endpoint is non-200, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed-to-get-well-known-config-response-from-api") {
+		t.Fatalf("expected well-known non-200 error, got: %v", err)
+	}
+}
+
 func TestHandleCallback(t *testing.T) {
 	testServer := testSetup()
 	defer testServer.Close()

--- a/connector/cloudfoundry/cloudfoundry_test.go
+++ b/connector/cloudfoundry/cloudfoundry_test.go
@@ -45,7 +45,7 @@ func TestHandleCallback(t *testing.T) {
 	expectEqual(t, err, nil)
 
 	t.Run("CallbackWithGroupsScope", func(t *testing.T) {
-		identity, err := cloudfoundryConn.HandleCallback(connector.Scopes{Groups: true}, req)
+		identity, err := cloudfoundryConn.HandleCallback(connector.Scopes{Groups: true}, nil, req)
 		expectEqual(t, err, nil)
 
 		expectEqual(t, len(identity.Groups), 24)
@@ -76,7 +76,7 @@ func TestHandleCallback(t *testing.T) {
 	})
 
 	t.Run("CallbackWithoutGroupsScope", func(t *testing.T) {
-		identity, err := cloudfoundryConn.HandleCallback(connector.Scopes{}, req)
+		identity, err := cloudfoundryConn.HandleCallback(connector.Scopes{}, nil, req)
 
 		expectEqual(t, err, nil)
 		expectEqual(t, identity.UserID, "12345")
@@ -84,7 +84,7 @@ func TestHandleCallback(t *testing.T) {
 	})
 
 	t.Run("CallbackWithOfflineAccessScope", func(t *testing.T) {
-		identity, err := cloudfoundryConn.HandleCallback(connector.Scopes{OfflineAccess: true}, req)
+		identity, err := cloudfoundryConn.HandleCallback(connector.Scopes{OfflineAccess: true}, nil, req)
 
 		expectEqual(t, err, nil)
 		expectNotEqual(t, len(identity.ConnectorData), 0)


### PR DESCRIPTION
#### Overview

related https://github.com/concourse/concourse/issues/9577
Update callback connector API and CF implementation.
- [x] CallbackConnector now carries connector state:
    - LoginURL(... ) returns (string, []byte, error)
    - HandleCallback(..., connData []byte, ...) accepts connector data
- [x] Cloud Foundry connector updated to match new signatures
- [x] CF Open() fixes:
    - check UAA well-known status via uaaResp.StatusCode
    - return error on Cloud Controller info JSON decode failure
- [x] Added test for non-200 UAA well-known response
- [x] Need to fully validate it on one of CF environments

#### Special notes for your reviewer

Validation: `go test ./connector/cloudfoundry`
